### PR TITLE
Remove unneeded inline specifier

### DIFF
--- a/src/syn.cpp
+++ b/src/syn.cpp
@@ -312,13 +312,13 @@ token_list lex(const char *p, lexer_flags flags)
 	return wlst;
 }
 
-inline std::string subst(const char *text)
+std::string subst(const char *text)
 {
 	if (!*text) return std::string();
 	return lex(text, SUBSTITUTE).elems[0];
 }
 
-inline std::string subst(std::string const& text)
+std::string subst(std::string const& text)
 {
 	return subst(text.c_str());
 }


### PR DESCRIPTION
The function is not in an header file, and regular overloading is enough here.

On my machine it caused linking errors instead:

    ld: /build/ccadO8sz.o: in function `expr(char const*)':
    lex.yy.cpp:(.text+0x1bf9): undefined reference to `subst[abi:cxx11](char const*)'

This change should not affect the optimization of the same name.