### PR TITLE
Rework makefile, following common conventions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,24 @@
-all: expr
+PREFIX = /usr/local
+SRCS = $(wildcard src/*.cpp src/*.hpp)
+CXXFLAGS = -std=gnu++11 -Wno-unused-result -O3
+
+.PHONY: all
+all: bin/zrc
+
+bin/zrc: $(SRCS) src/y.tab.cpp src/lex.yy.cpp
 	mkdir -p bin
-	$(CXX) -pedantic -std=gnu++11 -Wall -w src/lex.yy.c src/y.tab.c src/main.cpp -o bin/zrc
-	strip bin/zrc
+	$(CXX) $(CXXFLAGS) src/lex.yy.cpp src/y.tab.cpp src/main.cpp -o bin/zrc
+
+src/y.tab.cpp: src/expr.y
+	bison -d src/expr.y -o src/y.tab.cpp
+
+src/lex.yy.cpp: src/expr.l
+	flex -o src/lex.yy.cpp src/expr.l
+
+.PHONY: install
 install:
-	ln -sf $$(pwd) '/usr/lib/zrc'
-expr:
-	bison -d src/expr.y -o src/y.tab.c
-	flex -o src/lex.yy.c src/expr.l
+	install -Dm755 bin/zrc $(DESTDIR)$(PREFIX)/bin/zrc
+
+.PHONY: clean
 clean:
 	rm bin/*

--- a/src/expr.l
+++ b/src/expr.l
@@ -2,7 +2,7 @@
 #define YYSTYPE long double
 #include <iostream>
 #include <string>
-#include "y.tab.h"
+#include "y.tab.hpp"
 int yyparse();
 %}
 %option noyywrap


### PR DESCRIPTION
* Add configurable prefix, destdir, and flags.
* Remove redundant warning flags, leaving only -Wno-unused-result (the most common warning).
* Use dependencies where applicable.
* Mark phony targets as such.
* Remove strip call: it's good to have the option to do it (or not) at install/packaging time.
* Use the install command to install (symlinking leaves a dependency on the build directory).

---

This will make zrc easier to package